### PR TITLE
Item Scaling Enhancements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.12.5
 
 # Mod Properties
-	mod_version = 1.0.7
+	mod_version = 1.0.8
 	maven_group = net.backslotaddon
 	archives_base_name = backslotaddon
 

--- a/src/main/java/net/backslotaddon/mixin/BeltSlotFeatureRendererMixin.java
+++ b/src/main/java/net/backslotaddon/mixin/BeltSlotFeatureRendererMixin.java
@@ -1,5 +1,6 @@
 package net.backslotaddon.mixin;
 
+import net.minecraft.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -50,7 +51,10 @@ public class BeltSlotFeatureRendererMixin extends HeldItemFeatureRenderer<Abstra
                     matrixStack.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(-270.0F));
                     matrixStack.translate(0.23D, -0.25D, 0.28D);
                     matrixStack.scale(BackSlotMain.CONFIG.backslot_scale, BackSlotMain.CONFIG.backslot_scale, BackSlotMain.CONFIG.backslot_scale);
-                    MinecraftClient.getInstance().getHeldItemRenderer().renderItem(livingEntity, beltSlotStack, ModelTransformation.Mode.GROUND, false, matrixStack, vertexConsumerProvider, i);
+                    if (!livingEntity.hasStackEquipped(EquipmentSlot.CHEST)) { //Make items sit flush against back instead of floating when there's no chest plate in slot
+                        matrixStack.translate(0.0F, 0.0F, -0.04F);
+                    }
+                    MinecraftClient.getInstance().getHeldItemRenderer().renderItem(livingEntity, beltSlotStack, ModelTransformation.Mode.HEAD, false, matrixStack, vertexConsumerProvider, i);
                     matrixStack.pop();
                     info.cancel();
                 }


### PR DESCRIPTION
This is a sister change to go along with the item scaling enhancements for BackSlot, more info here: https://github.com/Globox1997/BackSlot/pull/62

- Version Bump
- Add Chestplate check for second sword to match change in https://github.com/Globox1997/BackSlot/pull/62
- change render from Ground to Head to match change in https://github.com/Globox1997/BackSlot/pull/62